### PR TITLE
Feature/trino history webui

### DIFF
--- a/FORK-README.md
+++ b/FORK-README.md
@@ -50,7 +50,7 @@ New releases from that branch are tagged as:
 
 6. Merge the feature branch:
 
-        git checkout trino-history-server-<version>-base
+        git checkout trino-history-server-<version>
 
         git merge feature-xyz
 

--- a/FORK-README.md
+++ b/FORK-README.md
@@ -1,0 +1,85 @@
+# Trino History Server Fork
+This fork of [Trino](https://github.com/trinodb/trino) is based on official release and includes custom modifications. This document provides steps to build the project and create a Docker image for your own deployments.
+
+## Extra Configurations
+
+This History Server Web UI fork introduces two additional configuration properties:
+
+```properties
+web-ui.history-server.url=http://example-history-server:8081
+web-ui.history-server.query-path=/api/v1/query/
+```
+
+## Feature Development
+
+In the history server fork, we treat `trino-history-server-<version>` as the fork's main branch for that Trino version.
+
+New releases from that branch are tagged as:
+
+- `trino-history-server-<version>.1 `
+- `trino-history-server-<version>.2`
+
+
+### Developing a new Feature
+
+1. Clone the fork locally:
+
+        git clone https://github.com/yardenc2003/trino.git
+
+2. If the fork is not yet based on the desired `trinodb/trino` version, create a new main branch from its tag:
+
+   * Add the upstream remote:
+ 
+           git remote add upstream https://github.com/trinodb/trino.git
+
+   * Fetch all tags:
+
+           git fetch upstream --tags
+
+   * Create the fork main's branch from the tag:
+
+           git checkout tags/<version> -b trino-history-server-<version>
+
+3. Create a new feature branch from the fork main:
+
+        git checkout -b feature-xyz trino-history-server-<version>
+
+4. Develop, commit and push.
+
+5. Open a pull request against the fork's main branch (`trino-history-server-<version>`).
+
+6. Merge the feature branch:
+
+        git checkout trino-history-server-<version>-base
+
+        git merge feature-xyz
+
+7. Create and push a new tag for the patch release:
+
+        git tag trino-history-server-<version>.1
+
+        git push origin trino-history-server-<version>.1
+
+## Building a Forked Custom Docker image
+
+To build a Docker image from your modified Trino fork:
+
+1. Run the Maven build: 
+
+    ```bash
+    ./mvnw clean install -DskipTests
+    ```
+
+2. Run the custom Docker build script, passing the Trino version you are based on:
+
+    ```bash
+    ./core/docker/trino-docker.sh 475
+    ```
+
+This will produce two Docker images for different architectures:
+
+* `trino-history:475-<arch>` — includes the Trino server, all plugins, and default configuration
+
+* `trino-history-core:475-<arch>` — includes only the core server with essential plugins
+
+After the build completes, make sure to tag the image appropriately to reflect the fork version.

--- a/README.md
+++ b/README.md
@@ -48,13 +48,6 @@ development process, and guidelines.
 
 See [CONTRIBUTING](.github/CONTRIBUTING.md) for contribution requirements.
 
-## Security
-
-See the project [security policy](.github/SECURITY.md) for
-information about reporting vulnerabilities.
-
-Trino supports [reproducible builds](https://reproducible-builds.org) as of version 449.
-
 ## Build requirements
 
 * Mac OS X or Linux
@@ -147,3 +140,9 @@ Run a query to see the nodes in the cluster:
 Run a query against the TPCH connector:
 
     SELECT * FROM tpch.tiny.region;
+
+---
+
+> 📢 **Note:** This is a personal fork of Trino, based on release tag `475`, with custom changes.
+>
+> For Docker image build instructions, upgrade process, and fork-specific notes, see [FORK-README.md](./FORK-README.md).

--- a/core/docker/trino-docker.sh
+++ b/core/docker/trino-docker.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -eux
+
+VERSION=$1
+architectures=(amd64 arm64 ppc64le)
+packages=(trino-server-core trino-server)
+tags=(trino-history-core trino-history)
+
+for index in "${!packages[@]}"; do
+    TAG=${tags[$index]}
+    TARGET=$TAG:$VERSION
+    core/docker/build.sh -a "$(IFS=, ; echo "${architectures[*]}")" -r "$VERSION" -p "${packages[$index]}" -t "$TAG"
+
+    for arch in "${architectures[@]}"; do
+        docker tag "$TAG:$VERSION-$arch" "$TARGET-$arch"
+    done
+done

--- a/core/trino-main/src/main/java/io/trino/server/ui/UiQueryResource.java
+++ b/core/trino-main/src/main/java/io/trino/server/ui/UiQueryResource.java
@@ -125,9 +125,19 @@ public class UiQueryResource
         throw new GoneException();
     }
 
+    private URI getHistoricalQueryUrl(QueryId queryId)
+    {
+        String path = String.format("%s%s%s",
+                historyServerUrl.endsWith("/") ? historyServerUrl : historyServerUrl + "/",
+                historyQueryPath.startsWith("/") ? historyQueryPath.substring(1) : historyQueryPath,
+                queryId);
+
+        return URI.create(path);
+    }
+
     private Response getQueryInfoFromHistoryServer(QueryId queryId)
     {
-        URI address = URI.create(historyServerUrl + historyQueryPath + queryId.toString());
+        URI address = getHistoricalQueryUrl(queryId);
         Request request = prepareGet().setUri(address).build();
         StringResponseHandler.StringResponse response;
 
@@ -137,11 +147,11 @@ public class UiQueryResource
         catch (RuntimeException e) {
             throw new InternalServerErrorException("Error getting query info from " + address, e);
         }
-        if (response.getStatusCode() == 400) {
-            throw new GoneException();
-        }
-        if (response.getStatusCode() == 500) {
-            throw new InternalServerErrorException();
+        if (response.getStatusCode() >= 400) {
+            if (response.getStatusCode() == 404 || response.getStatusCode() == 410) {
+                throw new GoneException();
+            }
+            throw new InternalServerErrorException("Unexpected error from history server: " + response.getStatusCode());
         }
 
         return Response.ok(response.getBody(), MediaType.APPLICATION_JSON).build();

--- a/core/trino-main/src/main/java/io/trino/server/ui/UiQueryResource.java
+++ b/core/trino-main/src/main/java/io/trino/server/ui/UiQueryResource.java
@@ -15,8 +15,11 @@ package io.trino.server.ui;
 
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
+import io.airlift.http.client.HttpClient;
+import io.airlift.http.client.Request;
+import io.airlift.http.client.StringResponseHandler;
+import io.airlift.log.Logger;
 import io.trino.dispatcher.DispatchManager;
-import io.trino.execution.QueryInfo;
 import io.trino.execution.QueryState;
 import io.trino.security.AccessControl;
 import io.trino.server.BasicQueryInfo;
@@ -30,24 +33,27 @@ import io.trino.spi.security.AccessDeniedException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.InternalServerErrorException;
 import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
 
+import java.net.URI;
 import java.util.List;
 import java.util.Locale;
 import java.util.NoSuchElementException;
-import java.util.Optional;
 
+import static io.airlift.http.client.Request.Builder.prepareGet;
+import static io.airlift.http.client.StringResponseHandler.createStringResponseHandler;
 import static io.trino.connector.system.KillQueryProcedure.createKillQueryException;
 import static io.trino.connector.system.KillQueryProcedure.createPreemptQueryException;
 import static io.trino.security.AccessControlUtil.checkCanKillQueryOwnedBy;
-import static io.trino.security.AccessControlUtil.checkCanViewQueryOwnedBy;
 import static io.trino.security.AccessControlUtil.filterQueries;
 import static io.trino.server.security.ResourceSecurity.AccessType.WEB_UI;
 import static java.util.Objects.requireNonNull;
@@ -60,13 +66,17 @@ public class UiQueryResource
     private final DispatchManager dispatchManager;
     private final AccessControl accessControl;
     private final HttpRequestSessionContextFactory sessionContextFactory;
+    private final HttpClient httpClient;
+    private final String historyServerUrl;
 
     @Inject
-    public UiQueryResource(DispatchManager dispatchManager, AccessControl accessControl, HttpRequestSessionContextFactory sessionContextFactory)
+    public UiQueryResource(DispatchManager dispatchManager, AccessControl accessControl, HttpRequestSessionContextFactory sessionContextFactory, @ForWebUi HttpClient httpClient, WebUiConfig webUiConfig)
     {
         this.dispatchManager = requireNonNull(dispatchManager, "dispatchManager is null");
         this.accessControl = requireNonNull(accessControl, "accessControl is null");
         this.sessionContextFactory = requireNonNull(sessionContextFactory, "sessionContextFactory is null");
+        this.httpClient = requireNonNull(httpClient, "httpClient is null");
+        this.historyServerUrl = requireNonNull(webUiConfig.getHistoryServerUrl(), "history server url is null");
     }
 
     @GET
@@ -90,19 +100,33 @@ public class UiQueryResource
     @Path("{queryId}")
     public Response getQueryInfo(@PathParam("queryId") QueryId queryId, @Context HttpServletRequest servletRequest, @Context HttpHeaders httpHeaders)
     {
+        Logger log = Logger.get(UiQueryResource.class);
         requireNonNull(queryId, "queryId is null");
 
-        Optional<QueryInfo> queryInfo = dispatchManager.getFullQueryInfo(queryId);
-        if (queryInfo.isPresent()) {
-            try {
-                checkCanViewQueryOwnedBy(sessionContextFactory.extractAuthorizedIdentity(servletRequest, httpHeaders), queryInfo.get().getSession().toIdentity(), accessControl);
-                return Response.ok(queryInfo.get().pruneDigests()).build();
-            }
-            catch (AccessDeniedException e) {
-                throw new ForbiddenException();
-            }
+        // Patch: performing an HTTP request to our REST history server for the complete query info (JSON)
+        URI address = getHistoryServertQueryUri(queryId);
+        Request request = prepareGet().setUri(address).build();
+        StringResponseHandler.StringResponse response;
+
+        try {
+            response = httpClient.execute(request, createStringResponseHandler());
         }
-        throw new GoneException();
+        catch (RuntimeException e) {
+            throw new InternalServerErrorException("Error getting query info from " + address, e);
+        }
+        if (response.getStatusCode() == 400) {
+            throw new GoneException();
+        }
+        if (response.getStatusCode() == 500) {
+            throw new InternalServerErrorException();
+        }
+
+        return Response.ok(response.getBody(), MediaType.APPLICATION_JSON).build();
+    }
+
+    private URI getHistoryServertQueryUri(QueryId queryId)
+    {
+        return URI.create(historyServerUrl + "/ui/api/query/" + queryId.toString());
     }
 
     @PUT

--- a/core/trino-main/src/main/java/io/trino/server/ui/UiQueryResource.java
+++ b/core/trino-main/src/main/java/io/trino/server/ui/UiQueryResource.java
@@ -18,7 +18,6 @@ import com.google.inject.Inject;
 import io.airlift.http.client.HttpClient;
 import io.airlift.http.client.Request;
 import io.airlift.http.client.StringResponseHandler;
-import io.airlift.log.Logger;
 import io.trino.dispatcher.DispatchManager;
 import io.trino.execution.QueryInfo;
 import io.trino.execution.QueryState;
@@ -72,6 +71,7 @@ public class UiQueryResource
     private final HttpRequestSessionContextFactory sessionContextFactory;
     private final HttpClient httpClient;
     @Nullable private final String historyServerUrl;
+    @Nullable private final String historyQueryPath;
 
     @Inject
     public UiQueryResource(DispatchManager dispatchManager, AccessControl accessControl, HttpRequestSessionContextFactory sessionContextFactory, @ForWebUi HttpClient httpClient, WebUiConfig webUiConfig)
@@ -81,6 +81,7 @@ public class UiQueryResource
         this.sessionContextFactory = requireNonNull(sessionContextFactory, "sessionContextFactory is null");
         this.httpClient = requireNonNull(httpClient, "httpClient is null");
         this.historyServerUrl = webUiConfig.getHistoryServerUrl();
+        this.historyQueryPath = webUiConfig.getHistoryQueryPath();
     }
 
     @GET
@@ -107,7 +108,7 @@ public class UiQueryResource
         requireNonNull(queryId, "queryId is null");
 
         // Patch: performing an HTTP request to REST history server for historical query info (JSON)
-        if (historyServerUrl != null){
+        if (historyServerUrl != null) {
             return getQueryInfoFromHistoryServer(queryId);
         }
 
@@ -124,8 +125,9 @@ public class UiQueryResource
         throw new GoneException();
     }
 
-    private Response getQueryInfoFromHistoryServer(QueryId queryId){
-        URI address = URI.create(historyServerUrl + "/ui/api/query/" + queryId.toString());
+    private Response getQueryInfoFromHistoryServer(QueryId queryId)
+    {
+        URI address = URI.create(historyServerUrl + historyQueryPath + queryId.toString());
         Request request = prepareGet().setUri(address).build();
         StringResponseHandler.StringResponse response;
 

--- a/core/trino-main/src/main/java/io/trino/server/ui/UiQueryResource.java
+++ b/core/trino-main/src/main/java/io/trino/server/ui/UiQueryResource.java
@@ -20,6 +20,7 @@ import io.airlift.http.client.Request;
 import io.airlift.http.client.StringResponseHandler;
 import io.airlift.log.Logger;
 import io.trino.dispatcher.DispatchManager;
+import io.trino.execution.QueryInfo;
 import io.trino.execution.QueryState;
 import io.trino.security.AccessControl;
 import io.trino.server.BasicQueryInfo;
@@ -30,6 +31,7 @@ import io.trino.server.security.ResourceSecurity;
 import io.trino.spi.QueryId;
 import io.trino.spi.TrinoException;
 import io.trino.spi.security.AccessDeniedException;
+import jakarta.annotation.Nullable;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.GET;
@@ -48,12 +50,14 @@ import java.net.URI;
 import java.util.List;
 import java.util.Locale;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 
 import static io.airlift.http.client.Request.Builder.prepareGet;
 import static io.airlift.http.client.StringResponseHandler.createStringResponseHandler;
 import static io.trino.connector.system.KillQueryProcedure.createKillQueryException;
 import static io.trino.connector.system.KillQueryProcedure.createPreemptQueryException;
 import static io.trino.security.AccessControlUtil.checkCanKillQueryOwnedBy;
+import static io.trino.security.AccessControlUtil.checkCanViewQueryOwnedBy;
 import static io.trino.security.AccessControlUtil.filterQueries;
 import static io.trino.server.security.ResourceSecurity.AccessType.WEB_UI;
 import static java.util.Objects.requireNonNull;
@@ -67,7 +71,7 @@ public class UiQueryResource
     private final AccessControl accessControl;
     private final HttpRequestSessionContextFactory sessionContextFactory;
     private final HttpClient httpClient;
-    private final String historyServerUrl;
+    @Nullable private final String historyServerUrl;
 
     @Inject
     public UiQueryResource(DispatchManager dispatchManager, AccessControl accessControl, HttpRequestSessionContextFactory sessionContextFactory, @ForWebUi HttpClient httpClient, WebUiConfig webUiConfig)
@@ -76,7 +80,7 @@ public class UiQueryResource
         this.accessControl = requireNonNull(accessControl, "accessControl is null");
         this.sessionContextFactory = requireNonNull(sessionContextFactory, "sessionContextFactory is null");
         this.httpClient = requireNonNull(httpClient, "httpClient is null");
-        this.historyServerUrl = requireNonNull(webUiConfig.getHistoryServerUrl(), "history server url is null");
+        this.historyServerUrl = webUiConfig.getHistoryServerUrl();
     }
 
     @GET
@@ -100,11 +104,28 @@ public class UiQueryResource
     @Path("{queryId}")
     public Response getQueryInfo(@PathParam("queryId") QueryId queryId, @Context HttpServletRequest servletRequest, @Context HttpHeaders httpHeaders)
     {
-        Logger log = Logger.get(UiQueryResource.class);
         requireNonNull(queryId, "queryId is null");
 
-        // Patch: performing an HTTP request to our REST history server for the complete query info (JSON)
-        URI address = getHistoryServertQueryUri(queryId);
+        // Patch: performing an HTTP request to REST history server for historical query info (JSON)
+        if (historyServerUrl != null){
+            return getQueryInfoFromHistoryServer(queryId);
+        }
+
+        Optional<QueryInfo> queryInfo = dispatchManager.getFullQueryInfo(queryId);
+        if (queryInfo.isPresent()) {
+            try {
+                checkCanViewQueryOwnedBy(sessionContextFactory.extractAuthorizedIdentity(servletRequest, httpHeaders), queryInfo.get().getSession().toIdentity(), accessControl);
+                return Response.ok(queryInfo.get().pruneDigests()).build();
+            }
+            catch (AccessDeniedException e) {
+                throw new ForbiddenException();
+            }
+        }
+        throw new GoneException();
+    }
+
+    private Response getQueryInfoFromHistoryServer(QueryId queryId){
+        URI address = URI.create(historyServerUrl + "/ui/api/query/" + queryId.toString());
         Request request = prepareGet().setUri(address).build();
         StringResponseHandler.StringResponse response;
 
@@ -122,11 +143,6 @@ public class UiQueryResource
         }
 
         return Response.ok(response.getBody(), MediaType.APPLICATION_JSON).build();
-    }
-
-    private URI getHistoryServertQueryUri(QueryId queryId)
-    {
-        return URI.create(historyServerUrl + "/ui/api/query/" + queryId.toString());
     }
 
     @PUT

--- a/core/trino-main/src/main/java/io/trino/server/ui/WebUiConfig.java
+++ b/core/trino-main/src/main/java/io/trino/server/ui/WebUiConfig.java
@@ -14,11 +14,13 @@
 package io.trino.server.ui;
 
 import io.airlift.configuration.Config;
+import jakarta.validation.constraints.NotEmpty;
 
 public class WebUiConfig
 {
     private boolean enabled = true;
     private boolean previewEnabled;
+    private String historyServerUrl;
 
     public boolean isEnabled()
     {
@@ -28,6 +30,12 @@ public class WebUiConfig
     public boolean isPreviewEnabled()
     {
         return previewEnabled;
+    }
+
+    @NotEmpty
+    public String getHistoryServerUrl()
+    {
+        return historyServerUrl;
     }
 
     @Config("web-ui.enabled")
@@ -41,6 +49,13 @@ public class WebUiConfig
     public WebUiConfig setPreviewEnabled(boolean previewEnabled)
     {
         this.previewEnabled = previewEnabled;
+        return this;
+    }
+
+    @Config("web-ui.history-server.url")
+    public WebUiConfig setHistoryServerUrl(String historyServerUrl)
+    {
+        this.historyServerUrl = historyServerUrl;
         return this;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/server/ui/WebUiConfig.java
+++ b/core/trino-main/src/main/java/io/trino/server/ui/WebUiConfig.java
@@ -14,7 +14,6 @@
 package io.trino.server.ui;
 
 import io.airlift.configuration.Config;
-import jakarta.validation.constraints.NotEmpty;
 
 public class WebUiConfig
 {

--- a/core/trino-main/src/main/java/io/trino/server/ui/WebUiConfig.java
+++ b/core/trino-main/src/main/java/io/trino/server/ui/WebUiConfig.java
@@ -32,7 +32,6 @@ public class WebUiConfig
         return previewEnabled;
     }
 
-    @NotEmpty
     public String getHistoryServerUrl()
     {
         return historyServerUrl;

--- a/core/trino-main/src/main/java/io/trino/server/ui/WebUiConfig.java
+++ b/core/trino-main/src/main/java/io/trino/server/ui/WebUiConfig.java
@@ -20,6 +20,7 @@ public class WebUiConfig
     private boolean enabled = true;
     private boolean previewEnabled;
     private String historyServerUrl;
+    private String historyQueryPath;
 
     public boolean isEnabled()
     {
@@ -34,6 +35,11 @@ public class WebUiConfig
     public String getHistoryServerUrl()
     {
         return historyServerUrl;
+    }
+
+    public String getHistoryQueryPath()
+    {
+        return historyQueryPath;
     }
 
     @Config("web-ui.enabled")
@@ -54,6 +60,13 @@ public class WebUiConfig
     public WebUiConfig setHistoryServerUrl(String historyServerUrl)
     {
         this.historyServerUrl = historyServerUrl;
+        return this;
+    }
+
+    @Config("web-ui.history-server.query-path")
+    public WebUiConfig setHistoryQueryPath(String historyQueryPath)
+    {
+        this.historyQueryPath = historyQueryPath;
         return this;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/server/ui/WebUiModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/ui/WebUiModule.java
@@ -18,6 +18,7 @@ import com.google.inject.Scopes;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
 
 import static io.airlift.configuration.ConfigBinder.configBinder;
+import static io.airlift.http.client.HttpClientBinder.httpClientBinder;
 import static io.airlift.jaxrs.JaxrsBinder.jaxrsBinder;
 
 public class WebUiModule
@@ -35,6 +36,7 @@ public class WebUiModule
             jaxrsBinder(binder).bind(ClusterResource.class);
             jaxrsBinder(binder).bind(ClusterStatsResource.class);
             jaxrsBinder(binder).bind(UiQueryResource.class);
+            httpClientBinder(binder).bindHttpClient("web-ui", ForWebUi.class);
 
             if (buildConfigObject(WebUiConfig.class).isPreviewEnabled()) {
                 install(new WebUiPreviewModule());


### PR DESCRIPTION
## Trino History Web UI Fork (v475)

This PR introduces the necessary changes to make Trino compatible with the [History Server](https://github.com/your-org/history-server) project.

### 🔧 Key Changes

- Modified the coordinator to fetch historical query JSONs from an external REST server (the History Server) for display in the Web UI.
- Added a custom Docker build script tailored for this fork.
- Included fork-specific documentation.

### 🎯 Purpose

The goal of this fork is to enable persistent visibility of historical queries in the Web UI. Instead of relying on in-memory query tracking, this version retrieves completed query data from a backend service (the History Server), which can store query information persistently.

### ⚠️ Usage Notice

> This fork is intended for **Web UI purposes only**.  
> It should **not** be used to execute queries, as the coordinator logic has been modified. Running queries directly from this node may lead to unexpected behavior.
